### PR TITLE
Add script file and README file

### DIFF
--- a/src/datasets/customer-support-ticket/README.md
+++ b/src/datasets/customer-support-ticket/README.md
@@ -1,0 +1,38 @@
+# Customer Support Ticket Dataset
+
+**Team**: Customer-Care
+
+**Description**: This dataset contains customer support ticket information, including customer details, product information, ticket specifics, and resolution details. It's designed to help analyze and improve customer support processes.
+
+**Dataset Link**: [Customer Support Ticket Dataset on Kaggle](https://www.kaggle.com/datasets/suraj520/customer-support-ticket-dataset)
+
+**Data Fields**:
+- Ticket ID: A unique identifier for each ticket.
+- Customer Name: The name of the customer who raised the ticket.
+- Customer Email: The email address of the customer (Domain name - @example.com is intentional for user data privacy concern).
+- Customer Age: The age of the customer.
+- Customer Gender: The gender of the customer.
+- Product Purchased: The tech product purchased by the customer.
+- Date of Purchase: The date when the product was purchased.
+- Ticket Type: The type of ticket (e.g., technical issue, billing inquiry, product inquiry).
+- Ticket Subject: The subject/topic of the ticket.
+- Ticket Description: The description of the customer's issue or inquiry.
+- Ticket Status: The status of the ticket (e.g., open, closed, pending customer response).
+- Resolution: The resolution or solution provided for closed tickets.
+- Ticket Priority: The priority level assigned to the ticket (e.g., low, medium, high, critical).
+- Ticket Channel: The channel through which the ticket was raised (e.g., email, phone, chat, social media).
+- First Response Time: The time taken to provide the first response to the customer.
+
+## How to Download
+
+To download the Customer Support Ticket Dataset:
+
+1. Visit the [dataset page on Kaggle](https://www.kaggle.com/datasets/suraj520/customer-support-ticket-dataset).
+2. Click on the "Download" button on the right side of the page.
+3. If you're not logged in, you'll be prompted to sign in or create a Kaggle account.
+4. Once logged in, the dataset will begin downloading as a zip file.
+5. Extract the contents of the zip file to access the dataset.
+
+## License
+
+The license for this dataset is not explicitly stated on the Kaggle page. Users should refer to Kaggle's general terms of use or contact the dataset owner for specific licensing information.

--- a/src/datasets/customer-support-ticket/main.py
+++ b/src/datasets/customer-support-ticket/main.py
@@ -1,44 +1,72 @@
 import csv
 import jsonlines
-from datetime import datetime
+import argparse
+import os
+import sys
 
 def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
-    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
-        csv_reader = csv.DictReader(csv_file)
-        
-        with jsonlines.open(jsonl_file_path, mode='w') as writer:
-            for id, row in enumerate(csv_reader):
-                text = (
-                    f"Ticket ID: {row['Ticket ID']}\n"
-                    f"Customer Name: {row['Customer Name']}\n"
-                    f"Customer Email: {row['Customer Email']}\n"
-                    f"Customer Age: {row['Customer Age']}\n"
-                    f"Customer Gender: {row['Customer Gender']}\n"
-                    f"Product Purchased: {row['Product Purchased']}\n"
-                    f"Date of Purchase: {row['Date of Purchase']}\n"
-                    f"Ticket Type: {row['Ticket Type']}\n"
-                    f"Ticket Subject: {row['Ticket Subject']}\n"
-                    f"Ticket Description: {row['Ticket Description']}\n"
-                    f"Ticket Status: {row['Ticket Status']}\n"
-                    f"Resolution: {row['Resolution']}\n"
-                    f"Ticket Priority: {row['Ticket Priority']}\n"
-                    f"Ticket Channel: {row['Ticket Channel']}\n"
-                    f"First Response Time: {row['First Response Time']}"
-                )
-                json_object = {
-                    'meta': {
-                        'dataset_link': dataset_link,
-                        'dataset_name': dataset_name,
-                        'id': id
-                    },
-                    'text': text
-                }
-                
-                writer.write(json_object)
+    try:
+        with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+            csv_reader = csv.DictReader(csv_file)
+            
+            with jsonlines.open(jsonl_file_path, mode='w') as writer:
+                for id, row in enumerate(csv_reader):
+                    text = (
+                        f"Ticket ID: {row.get('Ticket ID', '')}\n"
+                        f"Customer Name: {row.get('Customer Name', '')}\n"
+                        f"Customer Email: {row.get('Customer Email', '')}\n"
+                        f"Customer Age: {row.get('Customer Age', '')}\n"
+                        f"Customer Gender: {row.get('Customer Gender', '')}\n"
+                        f"Product Purchased: {row.get('Product Purchased', '')}\n"
+                        f"Date of Purchase: {row.get('Date of Purchase', '')}\n"
+                        f"Ticket Type: {row.get('Ticket Type', '')}\n"
+                        f"Ticket Subject: {row.get('Ticket Subject', '')}\n"
+                        f"Ticket Description: {row.get('Ticket Description', '')}\n"
+                        f"Ticket Status: {row.get('Ticket Status', '')}\n"
+                        f"Resolution: {row.get('Resolution', '')}\n"
+                        f"Ticket Priority: {row.get('Ticket Priority', '')}\n"
+                        f"Ticket Channel: {row.get('Ticket Channel', '')}\n"
+                        f"First Response Time: {row.get('First Response Time', '')}"
+                    )
+                    json_object = {
+                        'meta': {
+                            'dataset_link': dataset_link,
+                            'dataset_name': dataset_name,
+                            'id': id
+                        },
+                        'text': text
+                    }
+                    
+                    writer.write(json_object)
+        print(f"Conversion completed. Output file: {jsonl_file_path}")
+    except FileNotFoundError:
+        print(f"Error: The file {csv_file_path} was not found.")
+        sys.exit(1)
+    except csv.Error as e:
+        print(f"Error reading CSV file: {e}")
+        sys.exit(1)
+    except IOError as e:
+        print(f"I/O error occurred: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
-csv_file_path = 'customer_support_ticket.csv' 
-jsonl_file_path = 'cst.jsonl'  
-dataset_link = 'https://www.kaggle.com/datasets/suraj520/customer-support-ticket-dataset'  
-dataset_name = 'Customer Support Tickets Dataset'  
+def main():
+    parser = argparse.ArgumentParser(description="Convert CSV to JSONL")
+    parser.add_argument("csv_file", help="Path to the input CSV file")
+    parser.add_argument("jsonl_file", help="Path to the output JSONL file")
+    parser.add_argument("--dataset_link", default="https://www.kaggle.com/datasets/suraj520/customer-support-ticket-dataset", help="Dataset link")
+    parser.add_argument("--dataset_name", default="Customer Support Tickets Dataset", help="Dataset name")
+    
+    args = parser.parse_args()
 
-csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+    csv_file_path = args.csv_file
+    jsonl_file_path = args.jsonl_file
+    dataset_link = args.dataset_link
+    dataset_name = args.dataset_name
+
+    csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+
+if __name__ == "__main__":
+    main()

--- a/src/datasets/customer-support-ticket/main.py
+++ b/src/datasets/customer-support-ticket/main.py
@@ -1,0 +1,44 @@
+import csv
+import jsonlines
+from datetime import datetime
+
+def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
+    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        
+        with jsonlines.open(jsonl_file_path, mode='w') as writer:
+            for id, row in enumerate(csv_reader):
+                text = (
+                    f"Ticket ID: {row['Ticket ID']}\n"
+                    f"Customer Name: {row['Customer Name']}\n"
+                    f"Customer Email: {row['Customer Email']}\n"
+                    f"Customer Age: {row['Customer Age']}\n"
+                    f"Customer Gender: {row['Customer Gender']}\n"
+                    f"Product Purchased: {row['Product Purchased']}\n"
+                    f"Date of Purchase: {row['Date of Purchase']}\n"
+                    f"Ticket Type: {row['Ticket Type']}\n"
+                    f"Ticket Subject: {row['Ticket Subject']}\n"
+                    f"Ticket Description: {row['Ticket Description']}\n"
+                    f"Ticket Status: {row['Ticket Status']}\n"
+                    f"Resolution: {row['Resolution']}\n"
+                    f"Ticket Priority: {row['Ticket Priority']}\n"
+                    f"Ticket Channel: {row['Ticket Channel']}\n"
+                    f"First Response Time: {row['First Response Time']}"
+                )
+                json_object = {
+                    'meta': {
+                        'dataset_link': dataset_link,
+                        'dataset_name': dataset_name,
+                        'id': id
+                    },
+                    'text': text
+                }
+                
+                writer.write(json_object)
+
+csv_file_path = 'customer_support_ticket.csv' 
+jsonl_file_path = 'cst.jsonl'  
+dataset_link = 'https://www.kaggle.com/datasets/suraj520/customer-support-ticket-dataset'  
+dataset_name = 'Customer Support Tickets Dataset'  
+
+csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)

--- a/src/datasets/customer-transactions/README.md
+++ b/src/datasets/customer-transactions/README.md
@@ -1,0 +1,33 @@
+# Customer Transactions Dataset
+
+**Team**: Customer-Care
+
+**Description**: This dataset contains customer transaction information, including customer details and transaction specifics. It's designed to help analyze customer spending patterns and transaction behaviors.
+
+**Dataset Link**: [Customer Transactions Dataset on Kaggle](https://www.kaggle.com/datasets/bkcoban/customer-transactions)
+
+**Data Fields**:
+- Customer ID: The unique identifier for each customer.
+- Name: The customer's name.
+- Surname: The customer's last name.
+- Gender: The gender of the customer.
+- Birthdate: The customer's date of birth.
+- Transaction Amount: The amount of the transaction. ($)
+- Date: The date of the transaction.
+- Merchant Name: The name of the merchant where the transaction was made.
+- Category: The category of the transaction.
+
+## How to Download
+
+To download the Customer Transactions Dataset:
+
+1. Visit the [dataset page on Kaggle](https://www.kaggle.com/datasets/bkcoban/customer-transactions).
+2. Click on the "Download" button on the right side of the page.
+3. If you're not logged in, you'll be prompted to sign in or create a Kaggle account.
+4. Once logged in, the dataset will begin downloading as a zip file.
+5. Extract the contents of the zip file to access the dataset.
+
+## License
+
+The license for this dataset is not explicitly stated on the Kaggle page. Users should refer to Kaggle's general terms of use or contact the dataset owner for specific licensing information.
+

--- a/src/datasets/customer-transactions/main.py
+++ b/src/datasets/customer-transactions/main.py
@@ -1,38 +1,67 @@
 import csv
 import jsonlines
 from datetime import datetime
+import argparse
+import sys
 
 def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
-    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
-        csv_reader = csv.DictReader(csv_file)
-        
-        with jsonlines.open(jsonl_file_path, mode='w') as writer:
-            for id, row in enumerate(csv_reader):
-                text = (
-                    f"Customer ID: {row['Customer ID']}\n"
-                    f"Name: {row['Name']}\n"
-                    f"Surname: {row['Surname']}\n"
-                    f"Gender: {row['Gender']}\n"
-                    f"Birthdate: {row['Birthdate']}\n"
-                    f"Transaction Amount: {row['Transaction Amount']}\n"
-                    f"Date: {row['Date']}\n"
-                    f"Merchant Name: {row['Merchant Name']}\n"
-                    f"Category: {row['Category']}"
-                )
-                
-                json_object = {
-                    'meta': {
-                        'dataset_link': dataset_link,
-                        'dataset_name': dataset_name,
-                        'id': id
-                    },
-                    'text': text
-                }
-                
-                writer.write(json_object)
+    try:
+        with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+            csv_reader = csv.DictReader(csv_file)
+            
+            with jsonlines.open(jsonl_file_path, mode='w') as writer:
+                for id, row in enumerate(csv_reader):
+                    text = (
+                        f"Customer ID: {row.get('Customer ID', '')}\n"
+                        f"Name: {row.get('Name', '')}\n"
+                        f"Surname: {row.get('Surname', '')}\n"
+                        f"Gender: {row.get('Gender', '')}\n"
+                        f"Birthdate: {row.get('Birthdate', '')}\n"
+                        f"Transaction Amount: {row.get('Transaction Amount', '')}\n"
+                        f"Date: {row.get('Date', '')}\n"
+                        f"Merchant Name: {row.get('Merchant Name', '')}\n"
+                        f"Category: {row.get('Category', '')}"
+                    )
+                    
+                    json_object = {
+                        'meta': {
+                            'dataset_link': dataset_link,
+                            'dataset_name': dataset_name,
+                            'id': id
+                        },
+                        'text': text
+                    }
+                    
+                    writer.write(json_object)
+        print(f"Conversion completed. Output file: {jsonl_file_path}")
+    except FileNotFoundError:
+        print(f"Error: The file {csv_file_path} was not found.")
+        sys.exit(1)
+    except csv.Error as e:
+        print(f"Error reading CSV file: {e}")
+        sys.exit(1)
+    except IOError as e:
+        print(f"I/O error occurred: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
-csv_file_path = 'customer_transactions.csv'  
-jsonl_file_path = 'customer_transactions.jsonl'  
-dataset_link = 'https://www.kaggle.com/datasets/bkcoban/customer-transactions'  
-dataset_name = 'Customer Transaction Dataset' 
-csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+def main():
+    parser = argparse.ArgumentParser(description="Convert Customer Transactions CSV to JSONL")
+    parser.add_argument("csv_file", help="Path to the input CSV file")
+    parser.add_argument("jsonl_file", help="Path to the output JSONL file")
+    parser.add_argument("--dataset_link", default="https://www.kaggle.com/datasets/bkcoban/customer-transactions", help="Dataset link")
+    parser.add_argument("--dataset_name", default="Customer Transaction Dataset", help="Dataset name")
+    
+    args = parser.parse_args()
+
+    csv_file_path = args.csv_file
+    jsonl_file_path = args.jsonl_file
+    dataset_link = args.dataset_link
+    dataset_name = args.dataset_name
+
+    csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+
+if __name__ == "__main__":
+    main()

--- a/src/datasets/customer-transactions/main.py
+++ b/src/datasets/customer-transactions/main.py
@@ -1,0 +1,38 @@
+import csv
+import jsonlines
+from datetime import datetime
+
+def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
+    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        
+        with jsonlines.open(jsonl_file_path, mode='w') as writer:
+            for id, row in enumerate(csv_reader):
+                text = (
+                    f"Customer ID: {row['Customer ID']}\n"
+                    f"Name: {row['Name']}\n"
+                    f"Surname: {row['Surname']}\n"
+                    f"Gender: {row['Gender']}\n"
+                    f"Birthdate: {row['Birthdate']}\n"
+                    f"Transaction Amount: {row['Transaction Amount']}\n"
+                    f"Date: {row['Date']}\n"
+                    f"Merchant Name: {row['Merchant Name']}\n"
+                    f"Category: {row['Category']}"
+                )
+                
+                json_object = {
+                    'meta': {
+                        'dataset_link': dataset_link,
+                        'dataset_name': dataset_name,
+                        'id': id
+                    },
+                    'text': text
+                }
+                
+                writer.write(json_object)
+
+csv_file_path = 'customer_transactions.csv'  
+jsonl_file_path = 'customer_transactions.jsonl'  
+dataset_link = 'https://www.kaggle.com/datasets/bkcoban/customer-transactions'  
+dataset_name = 'Customer Transaction Dataset' 
+csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)

--- a/src/datasets/retail-transaction-dataset/README.md
+++ b/src/datasets/retail-transaction-dataset/README.md
@@ -1,6 +1,6 @@
 # Retail Transactional Dataset
 
-*Team Name*: PIISA  
+*Team Name*: Customer-Care  
 *Dataset Link*: [bhavikjikadara/Retail-Transactional-Dataset](https://www.kaggle.com/datasets/bhavikjikadara/retail-transactional-dataset)
 
 This dataset contains information on retail transactions, providing insights into customer purchasing behavior, product preferences, and sales trends. It can be used for various data analysis and machine learning tasks, such as customer segmentation, sales forecasting, and market basket analysis.

--- a/src/datasets/retail-transaction-dataset/README.md
+++ b/src/datasets/retail-transaction-dataset/README.md
@@ -1,0 +1,38 @@
+# Retail Transactional Dataset
+
+*Team Name*: PIISA  
+*Dataset Link*: [bhavikjikadara/Retail-Transactional-Dataset](https://www.kaggle.com/datasets/bhavikjikadara/retail-transactional-dataset)
+
+This dataset contains information on retail transactions, providing insights into customer purchasing behavior, product preferences, and sales trends. It can be used for various data analysis and machine learning tasks, such as customer segmentation, sales forecasting, and market basket analysis.
+
+## Dataset Fields
+- *Customer_ID*: Unique identifier for each customer.
+- *Name*: Full name of the customer.
+- *Email*: Email address of the customer.
+- *Phone*: Contact phone number of the customer.
+- *Address*: Street address of the customer.
+- *City*: City of residence for the customer.
+- *State*: State of residence for the customer.
+- *Zipcode*: Zip code for the customer's address.
+- *Country*: Country of residence for the customer.
+- *Age*: Age of the customer.
+- *Gender*: Gender of the customer.
+- *Income*: Annual income of the customer.
+- *Customer_Segment*: Segment category based on purchasing behavior.
+- *Date*: Date of the transaction.
+- *Year*: Year in which the transaction occurred.
+- *Month*: Month in which the transaction occurred.
+- *Product_Category*: Category of the purchased product.
+- *Product_Brand*: Brand of the purchased product.
+- *Product_Type*: Type or model of the purchased product.
+- *Feedback*: Customer feedback on the transaction.
+- *Shipping_Method*: Method used for shipping the product.
+- *Payment_Method*: Payment method chosen by the customer.
+- *Products*: List of products purchased in the transaction.
+
+## How to Download
+To download this dataset, follow these steps:
+
+1. *Kaggle API*: Use the Kaggle API to download the dataset directly by running:
+   ```bash
+   kaggle datasets download -d bhavikjikadara/retail-transactional-dataset

--- a/src/datasets/retail-transaction-dataset/main.py
+++ b/src/datasets/retail-transaction-dataset/main.py
@@ -1,50 +1,78 @@
 import csv
 import jsonlines
+import argparse
+import sys
 
 def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
-    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
-        csv_reader = csv.DictReader(csv_file)
-        
-        with jsonlines.open(jsonl_file_path, mode='w') as jsonl_file:
-            for id, row in enumerate(csv_reader):
-                text = (
-                    f"Customer_ID: {row['Customer_ID']}\n"
-                    f"Name: {row['Name']}\n"
-                    f"Email: {row['Email']}\n"
-                    f"Phone: {row['Phone']}\n"
-                    f"Address: {row['Address']}\n"
-                    f"City: {row['City']}\n"
-                    f"State: {row['State']}\n"
-                    f"Zipcode: {row['Zipcode']}\n"
-                    f"Country: {row['Country']}\n"
-                    f"Age: {row['Age']}\n"
-                    f"Gender: {row['Gender']}\n"
-                    f"Income: {row['Income']}\n"
-                    f"Customer_Segment: {row['Customer_Segment']}\n\n"
-                    f"Date: {row['Date']}\n"
-                    f"Year: {row['Year']}\n"
-                    f"Month: {row['Month']}\n"
-                    f"Product_Category: {row['Product_Category']}\n"
-                    f"Product_Brand: {row['Product_Brand']}\n"
-                    f"Product_Type: {row['Product_Type']}\n"
-                    f"Feedback: {row['Feedback']}\n"
-                    f"Shipping_Method: {row['Shipping_Method']}\n"
-                    f"Payment_Method: {row['Payment_Method']}\n"
-                    f"products: {row['products']}"
-                )   
-                json_line = {
-                    'meta': {
-                        'dataset_link': dataset_link,
-                        'dataset_name': dataset_name,
-                        'id': id
-                    },
-                    'text': text
-                }
-                jsonl_file.write(json_line)
+    try:
+        with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+            csv_reader = csv.DictReader(csv_file)
+            
+            with jsonlines.open(jsonl_file_path, mode='w') as jsonl_file:
+                for id, row in enumerate(csv_reader):
+                    text = (
+                        f"Customer_ID: {row.get('Customer_ID', '')}\n"
+                        f"Name: {row.get('Name', '')}\n"
+                        f"Email: {row.get('Email', '')}\n"
+                        f"Phone: {row.get('Phone', '')}\n"
+                        f"Address: {row.get('Address', '')}\n"
+                        f"City: {row.get('City', '')}\n"
+                        f"State: {row.get('State', '')}\n"
+                        f"Zipcode: {row.get('Zipcode', '')}\n"
+                        f"Country: {row.get('Country', '')}\n"
+                        f"Age: {row.get('Age', '')}\n"
+                        f"Gender: {row.get('Gender', '')}\n"
+                        f"Income: {row.get('Income', '')}\n"
+                        f"Customer_Segment: {row.get('Customer_Segment', '')}\n\n"
+                        f"Date: {row.get('Date', '')}\n"
+                        f"Year: {row.get('Year', '')}\n"
+                        f"Month: {row.get('Month', '')}\n"
+                        f"Product_Category: {row.get('Product_Category', '')}\n"
+                        f"Product_Brand: {row.get('Product_Brand', '')}\n"
+                        f"Product_Type: {row.get('Product_Type', '')}\n"
+                        f"Feedback: {row.get('Feedback', '')}\n"
+                        f"Shipping_Method: {row.get('Shipping_Method', '')}\n"
+                        f"Payment_Method: {row.get('Payment_Method', '')}\n"
+                        f"products: {row.get('products', '')}"
+                    )   
+                    json_line = {
+                        'meta': {
+                            'dataset_link': dataset_link,
+                            'dataset_name': dataset_name,
+                            'id': id
+                        },
+                        'text': text
+                    }
+                    jsonl_file.write(json_line)
+        print(f"Conversion completed. Output file: {jsonl_file_path}")
+    except FileNotFoundError:
+        print(f"Error: The file {csv_file_path} was not found.")
+        sys.exit(1)
+    except csv.Error as e:
+        print(f"Error reading CSV file: {e}")
+        sys.exit(1)
+    except IOError as e:
+        print(f"I/O error occurred: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
-csv_file_path = 'retail_sales.csv'  
-jsonl_file_path = 'retail_sales.jsonl'  
-dataset_link = 'https://www.kaggle.com/datasets/bhavikjikadara/retail-transactional-dataset/'
-dataset_name = 'Retail Transactional Dataset'
+def main():
+    parser = argparse.ArgumentParser(description="Convert Retail Sales CSV to JSONL")
+    parser.add_argument("csv_file", help="Path to the input CSV file")
+    parser.add_argument("jsonl_file", help="Path to the output JSONL file")
+    parser.add_argument("--dataset_link", default="https://www.kaggle.com/datasets/bhavikjikadara/retail-transactional-dataset/", help="Dataset link")
+    parser.add_argument("--dataset_name", default="Retail Transactional Dataset", help="Dataset name")
+    
+    args = parser.parse_args()
 
-csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+    csv_file_path = args.csv_file
+    jsonl_file_path = args.jsonl_file
+    dataset_link = args.dataset_link
+    dataset_name = args.dataset_name
+
+    csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)
+
+if __name__ == "__main__":
+    main()

--- a/src/datasets/retail-transaction-dataset/main.py
+++ b/src/datasets/retail-transaction-dataset/main.py
@@ -7,39 +7,38 @@ def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
         
         with jsonlines.open(jsonl_file_path, mode='w') as jsonl_file:
             for id, row in enumerate(csv_reader):
+                text = (
+                    f"Customer_ID: {row['Customer_ID']}\n"
+                    f"Name: {row['Name']}\n"
+                    f"Email: {row['Email']}\n"
+                    f"Phone: {row['Phone']}\n"
+                    f"Address: {row['Address']}\n"
+                    f"City: {row['City']}\n"
+                    f"State: {row['State']}\n"
+                    f"Zipcode: {row['Zipcode']}\n"
+                    f"Country: {row['Country']}\n"
+                    f"Age: {row['Age']}\n"
+                    f"Gender: {row['Gender']}\n"
+                    f"Income: {row['Income']}\n"
+                    f"Customer_Segment: {row['Customer_Segment']}\n\n"
+                    f"Date: {row['Date']}\n"
+                    f"Year: {row['Year']}\n"
+                    f"Month: {row['Month']}\n"
+                    f"Product_Category: {row['Product_Category']}\n"
+                    f"Product_Brand: {row['Product_Brand']}\n"
+                    f"Product_Type: {row['Product_Type']}\n"
+                    f"Feedback: {row['Feedback']}\n"
+                    f"Shipping_Method: {row['Shipping_Method']}\n"
+                    f"Payment_Method: {row['Payment_Method']}\n"
+                    f"products: {row['products']}"
+                )   
                 json_line = {
                     'meta': {
                         'dataset_link': dataset_link,
                         'dataset_name': dataset_name,
                         'id': id
                     },
-                    'customer_info': {
-                        'Customer_ID': row['Customer_ID'],
-                        'Name': row['Name'],
-                        'Email': row['Email'],
-                        'Phone': row['Phone'],
-                        'Address': row['Address'],
-                        'City': row['City'],
-                        'State': row['State'],
-                        'Zipcode': row['Zipcode'],
-                        'Country': row['Country'],
-                        'Age': row['Age'],
-                        'Gender': row['Gender'],
-                        'Income': row['Income'],
-                        'Customer_Segment': row['Customer_Segment'],
-                    },
-                    'purchase_info': {
-                        'Date': row['Date'],
-                        'Year': row['Year'],
-                        'Month': row['Month'],
-                        'Product_Category': row['Product_Category'],
-                        'Product_Brand': row['Product_Brand'],
-                        'Product_Type': row['Product_Type'],
-                        'Feedback': row['Feedback'],
-                        'Shipping_Method': row['Shipping_Method'],
-                        'Payment_Method': row['Payment_Method'],
-                        'products': row['products']
-                    }
+                    'text': text
                 }
                 jsonl_file.write(json_line)
 

--- a/src/datasets/retail-transaction-dataset/main.py
+++ b/src/datasets/retail-transaction-dataset/main.py
@@ -1,0 +1,51 @@
+import csv
+import jsonlines
+
+def csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name):
+    with open(csv_file_path, mode='r', encoding='utf-8') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        
+        with jsonlines.open(jsonl_file_path, mode='w') as jsonl_file:
+            for id, row in enumerate(csv_reader):
+                json_line = {
+                    'meta': {
+                        'dataset_link': dataset_link,
+                        'dataset_name': dataset_name,
+                        'id': id
+                    },
+                    'customer_info': {
+                        'Customer_ID': row['Customer_ID'],
+                        'Name': row['Name'],
+                        'Email': row['Email'],
+                        'Phone': row['Phone'],
+                        'Address': row['Address'],
+                        'City': row['City'],
+                        'State': row['State'],
+                        'Zipcode': row['Zipcode'],
+                        'Country': row['Country'],
+                        'Age': row['Age'],
+                        'Gender': row['Gender'],
+                        'Income': row['Income'],
+                        'Customer_Segment': row['Customer_Segment'],
+                    },
+                    'purchase_info': {
+                        'Date': row['Date'],
+                        'Year': row['Year'],
+                        'Month': row['Month'],
+                        'Product_Category': row['Product_Category'],
+                        'Product_Brand': row['Product_Brand'],
+                        'Product_Type': row['Product_Type'],
+                        'Feedback': row['Feedback'],
+                        'Shipping_Method': row['Shipping_Method'],
+                        'Payment_Method': row['Payment_Method'],
+                        'products': row['products']
+                    }
+                }
+                jsonl_file.write(json_line)
+
+csv_file_path = 'retail_sales.csv'  
+jsonl_file_path = 'retail_sales.jsonl'  
+dataset_link = 'https://www.kaggle.com/datasets/bhavikjikadara/retail-transactional-dataset/'
+dataset_name = 'Retail Transactional Dataset'
+
+csv_to_jsonl(csv_file_path, jsonl_file_path, dataset_link, dataset_name)


### PR DESCRIPTION
Add script file and README file for Retail Transaction Dataset

## Summary by Sourcery

Add a script to convert retail transaction data from CSV to JSONL format and include a README file with dataset details and download instructions.

New Features:
- Introduce a script to convert CSV files to JSONL format for the Retail Transaction Dataset.

Documentation:
- Add a README file for the Retail Transaction Dataset, detailing dataset fields and download instructions.